### PR TITLE
Add support for SSR

### DIFF
--- a/packages/mobx-devtools-mst/src/index.js
+++ b/packages/mobx-devtools-mst/src/index.js
@@ -1,11 +1,10 @@
 import * as mobx from 'mobx'; // eslint-disable-line
 import * as libmst from 'mobx-state-tree'; // eslint-disable-line
 
-const hook = window.__MOBX_DEVTOOLS_GLOBAL_HOOK__; // eslint-disable-line no-underscore-dangle
-if (hook && hook.inject) hook.inject({ mobx, mst: libmst });
-
-
 const track = (root) => {
+  const hook = window.__MOBX_DEVTOOLS_GLOBAL_HOOK__; // eslint-disable-line no-underscore-dangle
+  if (hook && hook.inject) hook.inject({ mobx, mst: libmst });
+
   if (!hook) return;
   for (const mobxid in hook.collections) {
     if (Object.prototype.hasOwnProperty.call(hook.collections, mobxid)) {


### PR DESCRIPTION
Hey, thanks for making a much improved devtools experience (esp. as a MST user!). I'm currently using Next.js along with MST and need support for server rendering on this package. Since [these lines](https://github.com/andykog/mobx-devtools/blob/6697e04e08d5a48cab812a327216926886e18d10/packages/mobx-devtools-mst/src/index.js#L4-L5
) are executed on import — which is often on the server — the package throws an error. 

If you instead moved those lines to inside the `track()` function, I could just do my own `isBrowser()` check and use these devtools with no problems. What do you think?