### PR TITLE
MST: track snapshots instead of patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixed
 - Fixed background page errors that prevented connecting to frontend
 
+### Changed
+- MST tab now displays snapshots instead of patches
+
 ## [0.9.12] - 2018-1-13
 ### Added
 - Actions' names in changes log (#15)

--- a/src/frontend/TabMST/LogItemExplorer.jsx
+++ b/src/frontend/TabMST/LogItemExplorer.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import injectStores from '../../utils/injectStores';
 import DataViewer from '../DataViewer';
 import Collapsible from '../Collapsible';
+import PreviewValue from '../PreviewValue';
 
 @injectStores({
   subscribe: ({ mstLoggerStore }) => {
@@ -55,14 +56,22 @@ export default class LogItemExplorer extends React.PureComponent {
             />
           </Collapsible>
         }
-        {this.props.logItem.patch && !this.props.initial &&
-          <Collapsible head={'Patch'} startOpen>
-            <DataViewer
-              path={['patch']}
-              getValueByPath={this.props.getValueByPath}
-              decorator={this.dataDecorator}
-            />
-          </Collapsible>
+        {this.props.logItem.patches && !this.props.initial && (
+          <div className={css(styles.patches)}>
+            {this.props.logItem.patches.map((patch) => {
+              const path = patch.path.replace(/^\//, '').replace(/\//g, '.');
+              switch (patch.op) {
+                case 'remove':
+                  return (
+                    <div>{path} <span className={css(styles.removedLabel)}>Removed</span></div>
+                  );
+                default: return (
+                  <div>{path} = <PreviewValue data={patch.value} /></div>
+                );
+              }
+            })}
+          </div>
+        )
         }
       </div>
     );
@@ -71,7 +80,17 @@ export default class LogItemExplorer extends React.PureComponent {
 
 const styles = StyleSheet.create({
   logExplorer: {
+    flex: '1 1 auto',
     padding: 5,
     overflow: 'auto',
+  },
+  patches: {
+    marginTop: 20,
+    paddingLeft: 15,
+  },
+  removedLabel: {
+    textTransform: 'uppercase',
+    fontSize: 10,
+    color: '#c41a16',
   },
 });

--- a/src/frontend/TabMST/MstLogItem.jsx
+++ b/src/frontend/TabMST/MstLogItem.jsx
@@ -1,23 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, css } from 'aphrodite';
-import PreviewValue from '../PreviewValue';
+import pluralize from '../../utils/pluralize';
 
 const getTitle = (logItem, initial) => {
   if (initial) {
     return 'Initial';
   }
-  if (logItem.patch) {
-    const path = logItem.patch.path.replace(/^\//, '').replace(/\//g, '.');
-    switch (logItem.patch.op) {
-      case 'remove':
-        return (
-          <span>{path} <span className={css(styles.removedLabel)}>Removed</span></span>
-        );
-      default: return (
-        <span>{path} = <PreviewValue data={logItem.patch.value} /></span>
-      );
-    }
+  if (logItem.patches) {
+    return `${logItem.patches.length} ${pluralize(logItem.patches.length, 'patch', 'patches')}`;
   }
   return 'Change';
 };
@@ -185,11 +176,7 @@ const styles = StyleSheet.create({
   titleSelected: {
     filter: 'contrast(0.1) brightness(2)',
   },
-  removedLabel: {
-    textTransform: 'uppercase',
-    fontSize: 10,
-    color: '#c41a16',
-  },
+
   rightButtons: {
     opacity: 'var(--log-item-buttons-pane-opacity)',
     display: 'flex',

--- a/src/utils/pluralize.js
+++ b/src/utils/pluralize.js
@@ -1,0 +1,4 @@
+export default (number, word, plural) => {
+  if (typeof number !== 'number' || (number % 100 !== 11 && number % 10 === 1)) return word;
+  return plural || `${word}s`;
+};


### PR DESCRIPTION
Right now every patch is shown seperately in MST tab without respect to transactions (actions). It leads to invalid state occuraces during time traveling. This PR makes only complete new snapshots apperar in MST tab.