### PR TITLE
Fix crash on undefined devtools property

### DIFF
--- a/src/shells/webextension/background.js
+++ b/src/shells/webextension/background.js
@@ -68,7 +68,9 @@ function isNumeric(str) {
 
 function handleInstallError(tabId, error) {
   if (__DEV__) console.warn(error); // eslint-disable-line no-console
-  const orphanDevtools = orphansByTabId[tabId].filter(p => !p.contentScript).map(p => p.devtools);
+  const orphanDevtools = orphansByTabId[tabId]
+    .filter(p => !p.contentScript && p.devtools !== undefined)
+    .map(p => p.devtools);
   orphanDevtools.forEach(d => d.postMessage('content-script-installation-error'));
 }
 


### PR DESCRIPTION
Orphaned tabs don't always have devtools attached. In that case the property `devtools` is `undefined`.

Fixes the following error:

<img width="704" alt="screen shot 2018-03-15 at 21 42 56" src="https://user-images.githubusercontent.com/1062408/37490071-ec3015b8-2899-11e8-9e87-a4b8242fb8c4.png">
