### PR TITLE
Include changes object key in display name.

### DIFF
--- a/src/backend/mobxLog.js
+++ b/src/backend/mobxLog.js
@@ -10,6 +10,7 @@ const summary = (change) => {
   sum.type = change.type;
   sum.name = change.name;
   sum.objectName = change.objectName;
+  sum.key = change.key;
   sum.oldValue = change.oldValue;
   sum.newValue = change.newValue;
   sum.hasChildren = change.children.length > 0;

--- a/src/frontend/TabChanges/LObjDiff.jsx
+++ b/src/frontend/TabChanges/LObjDiff.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css, StyleSheet } from 'aphrodite';
 import ChangeDataViewerPopover from './ChangeDataViewerPopover';
+import { changeDisplayName } from './utils';
 
 export default class LObjDiff extends React.PureComponent {
   static propTypes = {
@@ -19,16 +20,16 @@ export default class LObjDiff extends React.PureComponent {
     switch (change.type) {
       case 'add':
         return {
-          added: [{ name: change.name, value: change.newValue, path: ['newValue'] }],
+          added: [{ name: changeDisplayName(change), value: change.newValue, path: ['newValue'] }],
         };
       case 'delete':
         return {
-          removed: [{ name: change.name, value: change.oldValue, path: ['oldValue'] }],
+          removed: [{ name: changeDisplayName(change), value: change.oldValue, path: ['oldValue'] }],
         };
       case 'update':
         return {
-          added: [{ name: change.name, value: change.newValue, path: ['newValue'] }],
-          removed: [{ name: change.name, value: change.oldValue, path: ['oldValue'] }],
+          added: [{ name: changeDisplayName(change), value: change.newValue, path: ['newValue'] }],
+          removed: [{ name: changeDisplayName(change), value: change.oldValue, path: ['oldValue'] }],
         };
       case 'splice':
         return {

--- a/src/frontend/TabChanges/LogItem.jsx
+++ b/src/frontend/TabChanges/LogItem.jsx
@@ -7,6 +7,7 @@ import { IconComputed, IconScheduledReaction, IconError } from './icons';
 import injectStores from '../../utils/injectStores';
 import Popover from '../Popover';
 import ChangeDataViewerPopover from './ChangeDataViewerPopover';
+import { changeDisplayName } from './utils';
 
 const getColor = (type) => {
   switch (type) {
@@ -102,7 +103,7 @@ export default class LogItem extends React.Component {
               <ChangeDataViewerPopover
                 path={this.props.path.concat(['object'])}
                 value={change.object}
-                displayName={change.objectName}
+                displayName={changeDisplayName(change)}
                 getValueByPath={this.props.getValueByPath}
                 inspect={this.props.inspect}
                 stopInspecting={this.props.stopInspecting}
@@ -122,7 +123,7 @@ export default class LogItem extends React.Component {
             <ChangeDataViewerPopover
               path={this.props.path.concat(['object'])}
               value={change.object}
-              displayName={change.objectName}
+              displayName={changeDisplayName(change)}
               getValueByPath={this.props.getValueByPath}
               inspect={this.props.inspect}
               stopInspecting={this.props.stopInspecting}
@@ -160,7 +161,7 @@ export default class LogItem extends React.Component {
               <ChangeDataViewerPopover
                 path={this.props.path.concat(['object'])}
                 value={change.object}
-                displayName={change.objectName}
+                displayName={changeDisplayName(change)}
                 getValueByPath={this.props.getValueByPath}
                 inspect={this.props.inspect}
                 stopInspecting={this.props.stopInspecting}
@@ -196,7 +197,7 @@ export default class LogItem extends React.Component {
             <ChangeDataViewerPopover
               path={this.props.path.concat(['object'])}
               value={change.object}
-              displayName={change.objectName}
+              displayName={changeDisplayName(change)}
               getValueByPath={this.props.getValueByPath}
               inspect={this.props.inspect}
               stopInspecting={this.props.stopInspecting}
@@ -213,7 +214,7 @@ export default class LogItem extends React.Component {
             <ChangeDataViewerPopover
               path={this.props.path.concat(['object'])}
               value={change.object}
-              displayName={change.objectName}
+              displayName={changeDisplayName(change)}
               getValueByPath={this.props.getValueByPath}
               inspect={this.props.inspect}
               stopInspecting={this.props.stopInspecting}

--- a/src/frontend/TabChanges/utils.js
+++ b/src/frontend/TabChanges/utils.js
@@ -1,0 +1,6 @@
+export default function changeDisplayName(change) {
+  if (change.key) {
+    return `${change.objectName}.${change.key}`;
+  }
+  return change.objectName;
+}


### PR DESCRIPTION
This makes change logs more useful by including which field of an object
may have changed instead of just mentioning the objects name.

Example screenshot:
![screenshot from 2019-02-16 18-33-30](https://user-images.githubusercontent.com/7072461/52907607-9791d980-3219-11e9-933d-0b61a9d26715.png)

Let me know what you think. I found this very helpful when using mobx-devtools. 