### PR TITLE
Fix mobx-devtools-mst peer dependency for MobX

### DIFF
--- a/packages/mobx-devtools-mst/package.json
+++ b/packages/mobx-devtools-mst/package.json
@@ -23,7 +23,7 @@
     "build": "cross-env NODE_ENV=production webpack"
   },
   "peerDependencies": {
-    "mobx": "^2.2.0 || ^3.0.0 || ^4.0.0 | ^5.0.0",
+    "mobx": "^2.2.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
     "mobx-state-tree": "*"
   }
 }


### PR DESCRIPTION
A missing pipe meant that valid versions (such as MobX 4.3.2) would not match. This would fix #36