### PR TITLE
Fix postMessage error

### DIFF
--- a/src/shells/webextension/backend.js
+++ b/src/shells/webextension/backend.js
@@ -32,8 +32,11 @@ function handshake(hook, contentScriptId) {
     },
     send(data) {
       debugConnection('[BACKEND -> contentScript]', data);
+      
+      const payload = JSON.parse(JSON.stringify(data));
+      
       window.postMessage(
-        { source: 'mobx-devtools-backend', payload: data, contentScriptId, backendId },
+        { source: 'mobx-devtools-backend', payload, contentScriptId, backendId },
         '*'
       );
     },


### PR DESCRIPTION
When I tried to inspect a map with nested objects, I had got the following error `Uncaught DOMException: Failed to execute 'postMessage' on 'Window': [object Object] could not be cloned`. I think this commit should fix it