### PR TITLE
Fixed typo for component sizing

### DIFF
--- a/src/frontend/SplitPane.jsx
+++ b/src/frontend/SplitPane.jsx
@@ -46,7 +46,7 @@ export default class SplitPane extends React.Component {
 
         this.setState(
           {
-            width: Math.min(250, width),
+            width: Math.max(250, width),
             height: Math.floor(this.el.offsetHeight * 0.3),
             isVertical,
           },


### PR DESCRIPTION
* Fixed typo causing right-side of Components panel to always start at 250px, rather than the intended 60%.