### PR TITLE
Added vertical scrolling to solve issue #59

### DIFF
--- a/src/frontend/TabMST/LogItemExplorer.jsx
+++ b/src/frontend/TabMST/LogItemExplorer.jsx
@@ -83,6 +83,7 @@ const styles = StyleSheet.create({
     flex: '1 1 auto',
     padding: 5,
     overflow: 'auto',
+    maxHeight: '95vh',
   },
   patches: {
     marginTop: 20,


### PR DESCRIPTION
"Unable to vertically scroll in MST package #59"

"Way to fix MST panel:adding maxHeight: '95vh' to src/frontend/TabMST/LogItemExplorer.jsx > styles.logExplorer."