### PR TITLE
Enable nodeIntegration in the standalone electron app

### DIFF
--- a/packages/mobx-devtools/app/index.js
+++ b/packages/mobx-devtools/app/index.js
@@ -11,5 +11,8 @@ app.on('ready', () => {
     width: 800,
     height: 600,
     icon: path.join(__dirname, 'icons/icon128.png'),
+    webPreferences: {
+			nodeIntegration: true,
+		},
   }).loadURL(`file://${__dirname}/index.html`); // eslint-disable-line no-path-concat
 });

--- a/packages/mobx-devtools/app/index.js
+++ b/packages/mobx-devtools/app/index.js
@@ -12,7 +12,7 @@ app.on('ready', () => {
     height: 600,
     icon: path.join(__dirname, 'icons/icon128.png'),
     webPreferences: {
-			nodeIntegration: true,
-		},
+      nodeIntegration: true,
+    },
   }).loadURL(`file://${__dirname}/index.html`); // eslint-disable-line no-path-concat
 });


### PR DESCRIPTION
Fixes "require is not defined" in Electron. Since version 5.0.0 Electron sets `nodeIntegration` as false by default.