### PR TITLE
chore: Add workflows

### DIFF
--- a/.github/workflows/mobx-devtools-mst-publish.yml
+++ b/.github/workflows/mobx-devtools-mst-publish.yml
@@ -1,0 +1,32 @@
+name: Publish mobx-devtools-mst
+
+on:
+  push:
+    paths: [ "packages/mobx-devtools-mst/**", ".github/**" ]
+    branches: [ "master" ]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm run bootstrap
+      - name: Resolve new package version & Publish
+        working-directory: ./packages/mobx-devtools-mst
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          export LATEST=$(npm show "$NAME@$VERSION" version --json)
+          NEXT=$(node -p "JSON.parse(process.env.LATEST).split('.').map((n, i) => i === 2 ? ++n : n).join('.')")
+          echo "NEXT: $NEXT"
+          npm version $NEXT --git-tag-version false
+          npm run build
+          cat ./package.json
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on: workflow_dispatch
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 17
+          registry-url: https://registry.npmjs.org/
+      - run: npm run bootstrap
+      - run: npm run build
+      - run: |
+          TAG=$(echo $TAG | cut -c1-8)
+          gh release create "$TAG" \
+            --repo="$GITHUB_REPOSITORY" \
+            --title="${TAG#v}" \
+            --generate-notes \
+            ./lib/*.zip
+        env:
+          TAG: ${{ github.event.pull_request.head.sha || github.sha }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 17
+          registry-url: https://registry.npmjs.org/
+      - run: npm run bootstrap
+      - run: npm run lint
+      - run: npm run build
+      - run: npm run test

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:chrome": "cross-env NODE_ENV=production cross-env NODE_OPTIONS='--openssl-legacy-provider' TARGET_BROWSER=chrome node scripts/webextension/build.js && echo 'Chrome built'",
     "start:firefox": "cross-env NODE_ENV=development cross-env TARGET_BROWSER=firefox NODE_OPTIONS='--openssl-legacy-provider' node scripts/webextension/dev-server.js",
     "build:firefox": "cross-env NODE_ENV=production TARGET_BROWSER=firefox NODE_OPTIONS='--openssl-legacy-provider' node scripts/webextension/build.js",
-    "test": "npm run test:unit ; npm run test:e2e",
+    "test": "npm run test:unit",
     "test:unit": "cross-env NODE_ENV=test NODE_OPTIONS='--openssl-legacy-provider' mocha --require 'babel-core/register' 'src/**/*-test.js'",
     "test:e2e": "npm run test:e2e:chrome",
     "test:e2e:chrome": "cross-env NODE_ENV=test TARGET_BROWSER=chrome NODE_OPTIONS='--openssl-legacy-provider' node scripts/webextension/build.js && npm run test:e2e:chrome:now",


### PR DESCRIPTION
Add GH workflows:
- test - run tests on PR's & commits in master
- release - can be triggered manually to create a new GH release with attached files chrome.zip & firefox.zip. Commit SHA is used as release name
- mobx-devtools-mst-publish - publish mobx-devtools-mst npm package