### PR TITLE
chore: Use pull_request_target in workflow instead of pull_request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches: [ "master" ]
-  pull_request:
+  pull_request_target:
     branches: [ "master" ]
 
 jobs:


### PR DESCRIPTION
This should always run workflow version from master even if it was modified in PR