### PR TITLE
chore: Update minimum version in manifest.json

### DIFF
--- a/src/shells/webextension/manifest.json
+++ b/src/shells/webextension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MobX Developer Tools",
   "description": "Adds MobX debugging tools to the Chrome Developer Tools.",
-  "minimum_chrome_version": "44",
+  "minimum_chrome_version": "88",
   "applications": {
     "gecko": {
       "id": "@mobx",


### PR DESCRIPTION
Should fix this error from chrome store on attempt to upload a new version:
> There was a problem uploading your file. Please try again.
The minimum Chrome version of 44 does not meet the minimum requirement to be published. To be published, a manifest V3 item must require at least Chrome version 88.