### PR TITLE
fix: global hook not installing

### DIFF
--- a/src/shells/webextension/injectGlobalHook.js
+++ b/src/shells/webextension/injectGlobalHook.js
@@ -1,9 +1,11 @@
 // Simply importing this file will install the global hook here
 import installGlobalHook from '../../backend/utils/installGlobalHook';
 
-// if (__DEV__) {
-window.addEventListener('test-open-mobx-devtools-window', () => {
-  console.log('test-open-mobx-devtools-window'); // eslint-disable-line no-console
-  chrome.runtime.sendMessage({ eventName: 'open-mobx-devtools-window' });
-});
-// }
+if (__DEV__) {
+  window.addEventListener('test-open-mobx-devtools-window', () => {
+    console.log('test-open-mobx-devtools-window'); // eslint-disable-line no-console
+    chrome.runtime.sendMessage({ eventName: 'open-mobx-devtools-window' });
+  });
+}
+
+installGlobalHook(window);

--- a/src/shells/webextension/manifest.json
+++ b/src/shells/webextension/manifest.json
@@ -41,20 +41,12 @@
   "permissions": ["contextMenus", "storage", "scripting"],
   "host_permissions": ["<all_urls>"],
 
-  "browser_action": {
-    "default_icon": {
-      "16": "icons/toolbar-chrome.png",
-      "32": "icons/toolbar-chrome@2x.png"
-    },
-    "default_title": "Open"
-  },
-
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
       "js": ["injectGlobalHook.js"],
-      "run_at": "document_start"
+      "run_at": "document_start",
+      "world": "MAIN"
     }
   ]
-
 }

--- a/src/shells/webextension/panel-loader.js
+++ b/src/shells/webextension/panel-loader.js
@@ -16,7 +16,7 @@ function createPanelIfMobxLoaded() {
       world: 'MAIN',
     })
     .then(([result]) => {
-      const pageHasMobx = result?.result; // Access the result property
+      const pageHasMobx = result?.result;
 
       if (!pageHasMobx || panelCreated) {
         return;


### PR DESCRIPTION
Fixes the problem noted in [this comment](https://github.com/mobxjs/mobx-devtools/pull/129#discussion_r1866825413) that the MobX tab stopped loading.

You should be able to verify this by:

1. Remove any MobX Devtools extension you have
2. Run `npm run build` on this branch
3. Install the MobX Devtools 
4. Run `npm run start-playground`
5. Open up http://localhost:8082/amsterdam.html
6. Inspect, see MobX devtools