### PR TITLE
test: Add e2e tests for Changes tab and MST tab

### DIFF
--- a/test/e2e/mobxReactObservers.js
+++ b/test/e2e/mobxReactObservers.js
@@ -51,11 +51,13 @@ describe('Changes tab', function test() {
 
     // Verify log entries appeared
     assert.isAtLeast(
-      await devtoolPage.locator('text=manuallyIncrease').count(), 1,
+      await devtoolPage.locator('text=manuallyIncrease').count(),
+      1,
       'Expected manuallyIncrease log entries',
     );
     assert.isAtLeast(
-      await devtoolPage.locator('text=manuallyDecrease').count(), 1,
+      await devtoolPage.locator('text=manuallyDecrease').count(),
+      1,
       'Expected manuallyDecrease log entries',
     );
   });
@@ -67,15 +69,21 @@ describe('Changes tab', function test() {
     await searchInput.fill('manuallyIncrease');
     await devtoolPage.waitForTimeout(1000);
     assert.isAtLeast(await devtoolPage.locator('text=manuallyIncrease').count(), 1);
-    assert.equal(await devtoolPage.locator('text=manuallyDecrease').count(), 0,
-      'manuallyDecrease should be filtered out');
+    assert.equal(
+      await devtoolPage.locator('text=manuallyDecrease').count(),
+      0,
+      'manuallyDecrease should be filtered out',
+    );
 
     // Regex filter
     await searchInput.fill('/manually[Dd]ecrease');
     await devtoolPage.waitForTimeout(1000);
     assert.isAtLeast(await devtoolPage.locator('text=manuallyDecrease').count(), 1);
-    assert.equal(await devtoolPage.locator('text=manuallyIncrease').count(), 0,
-      'manuallyIncrease should not match regex');
+    assert.equal(
+      await devtoolPage.locator('text=manuallyIncrease').count(),
+      0,
+      'manuallyIncrease should not match regex',
+    );
 
     await searchInput.fill('');
     await devtoolPage.waitForTimeout(500);
@@ -86,14 +94,25 @@ describe('Changes tab', function test() {
     assert.isAtLeast(await devtoolPage.locator('text=manuallyIncrease').count(), 1);
     await clickClearButton();
     await devtoolPage.waitForTimeout(1000);
-    assert.equal(await devtoolPage.locator('text=manuallyIncrease').count(), 0, 'Log should be empty after clear');
-    assert.equal(await devtoolPage.locator('text=manuallyDecrease').count(), 0, 'Log should be empty after clear');
+    assert.equal(
+      await devtoolPage.locator('text=manuallyIncrease').count(),
+      0,
+      'Log should be empty after clear',
+    );
+    assert.equal(
+      await devtoolPage.locator('text=manuallyDecrease').count(),
+      0,
+      'Log should be empty after clear',
+    );
 
     // Verify recording still works after clear
     await mainPage.locator('button', { hasText: '+' }).click();
     await devtoolPage.waitForTimeout(2000);
-    assert.isAtLeast(await devtoolPage.locator('text=manuallyIncrease').count(), 1,
-      'New changes should appear after clearing');
+    assert.isAtLeast(
+      await devtoolPage.locator('text=manuallyIncrease').count(),
+      1,
+      'New changes should appear after clearing',
+    );
 
     // Stop recording
     await startRecording();
@@ -102,7 +121,10 @@ describe('Changes tab', function test() {
     await mainPage.locator('button', { hasText: '+' }).click();
     await mainPage.locator('button', { hasText: '+' }).click();
     await devtoolPage.waitForTimeout(2000);
-    assert.equal(await devtoolPage.locator('text=manuallyIncrease').count(), 0,
-      'No changes should be recorded when stopped');
+    assert.equal(
+      await devtoolPage.locator('text=manuallyIncrease').count(),
+      0,
+      'No changes should be recorded when stopped',
+    );
   });
 });

--- a/test/e2e/mobxReactObservers.js
+++ b/test/e2e/mobxReactObservers.js
@@ -2,15 +2,19 @@ const { assert } = require('chai');
 const prepare = require('../prepare');
 const { startDevServer } = require('../../packages/playground/webpack.makeConfig');
 
-describe('Components (observers) devtool', function test() {
-  let driver;
+describe('Changes tab', function test() {
+  let mainPage;
+  let devtoolPage;
   let teardown;
   let closePlayground;
   this.timeout(100000);
 
   before(async () => {
     closePlayground = await startDevServer({ port: 8082, pages: ['baltimore'] });
-    ({ driver, teardown } = await prepare({ initialUrl: 'http://localhost:8082/baltimore.html' }));
+    const result = await prepare({ initialUrl: 'http://localhost:8082/baltimore.html' });
+    mainPage = result.mainWindowHandle;
+    devtoolPage = result.devtoolWindowHandle;
+    teardown = result.teardown;
   });
 
   after(async () => {
@@ -18,8 +22,87 @@ describe('Components (observers) devtool', function test() {
     if (teardown) await teardown();
   });
 
-  // This test used to check for the components tab which has been removed, but we will leave the test set up here for the future.
-  it('should load components tree', async () => {
-    assert.ok(true);
+  const startRecording = async () => {
+    const toolbar = devtoolPage.locator('input[placeholder="Search (string/regex)"]').locator('..');
+    await toolbar.locator('> div').first().click();
+  };
+
+  const clickClearButton = async () => {
+    const toolbar = devtoolPage.locator('input[placeholder="Search (string/regex)"]').locator('..');
+    await toolbar.locator('> div').nth(1).click();
+  };
+
+  it('should record and display MobX changes', async () => {
+    // Initially shows a tip to start recording
+    const tip = devtoolPage.locator('text=Click to start recording');
+    await tip.waitFor({ timeout: 5000 });
+    assert.isTrue(await tip.isVisible());
+
+    // Start recording
+    await startRecording();
+    await devtoolPage.waitForTimeout(500);
+    assert.isFalse(await tip.isVisible(), 'Tip should disappear after starting recording');
+
+    // Perform actions on the main page
+    await mainPage.locator('button', { hasText: '+' }).click();
+    await mainPage.locator('button', { hasText: '+' }).click();
+    await mainPage.locator('button', { hasText: '–' }).click();
+    await devtoolPage.waitForTimeout(2000);
+
+    // Verify log entries appeared
+    assert.isAtLeast(
+      await devtoolPage.locator('text=manuallyIncrease').count(), 1,
+      'Expected manuallyIncrease log entries',
+    );
+    assert.isAtLeast(
+      await devtoolPage.locator('text=manuallyDecrease').count(), 1,
+      'Expected manuallyDecrease log entries',
+    );
+  });
+
+  it('should filter log entries by text and regex search', async () => {
+    const searchInput = devtoolPage.locator('input[placeholder="Search (string/regex)"]');
+
+    // Text filter
+    await searchInput.fill('manuallyIncrease');
+    await devtoolPage.waitForTimeout(1000);
+    assert.isAtLeast(await devtoolPage.locator('text=manuallyIncrease').count(), 1);
+    assert.equal(await devtoolPage.locator('text=manuallyDecrease').count(), 0,
+      'manuallyDecrease should be filtered out');
+
+    // Regex filter
+    await searchInput.fill('/manually[Dd]ecrease');
+    await devtoolPage.waitForTimeout(1000);
+    assert.isAtLeast(await devtoolPage.locator('text=manuallyDecrease').count(), 1);
+    assert.equal(await devtoolPage.locator('text=manuallyIncrease').count(), 0,
+      'manuallyIncrease should not match regex');
+
+    await searchInput.fill('');
+    await devtoolPage.waitForTimeout(500);
+  });
+
+  it('should clear log and stop recording', async () => {
+    // Clear log
+    assert.isAtLeast(await devtoolPage.locator('text=manuallyIncrease').count(), 1);
+    await clickClearButton();
+    await devtoolPage.waitForTimeout(1000);
+    assert.equal(await devtoolPage.locator('text=manuallyIncrease').count(), 0, 'Log should be empty after clear');
+    assert.equal(await devtoolPage.locator('text=manuallyDecrease').count(), 0, 'Log should be empty after clear');
+
+    // Verify recording still works after clear
+    await mainPage.locator('button', { hasText: '+' }).click();
+    await devtoolPage.waitForTimeout(2000);
+    assert.isAtLeast(await devtoolPage.locator('text=manuallyIncrease').count(), 1,
+      'New changes should appear after clearing');
+
+    // Stop recording
+    await startRecording();
+    await clickClearButton();
+    await devtoolPage.waitForTimeout(500);
+    await mainPage.locator('button', { hasText: '+' }).click();
+    await mainPage.locator('button', { hasText: '+' }).click();
+    await devtoolPage.waitForTimeout(2000);
+    assert.equal(await devtoolPage.locator('text=manuallyIncrease').count(), 0,
+      'No changes should be recorded when stopped');
   });
 });

--- a/test/e2e/mstDevtool.js
+++ b/test/e2e/mstDevtool.js
@@ -1,0 +1,92 @@
+const { assert } = require('chai');
+const prepare = require('../prepare');
+const { startDevServer } = require('../../packages/playground/webpack.makeConfig');
+
+describe('MST tab', function test() {
+  let mainPage;
+  let devtoolPage;
+  let teardown;
+  let closePlayground;
+  this.timeout(100000);
+
+  before(async () => {
+    closePlayground = await startDevServer({ port: 8082, pages: ['casablanca'] });
+    const result = await prepare({ initialUrl: 'http://localhost:8082/casablanca.html' });
+    mainPage = result.mainWindowHandle;
+    devtoolPage = result.devtoolWindowHandle;
+    teardown = result.teardown;
+  });
+
+  after(async () => {
+    if (closePlayground) closePlayground();
+    if (teardown) await teardown();
+  });
+
+  const addTodo = async (title) => {
+    const input = mainPage.locator('input');
+    await input.fill(title);
+    await input.press('Enter');
+  };
+
+  const clickClearButton = async () => {
+    // Click the parent div of the ClearIcon SVG (which has a unique circle with r="5.75")
+    await devtoolPage.locator('svg:has(circle[r="5.75"])').locator('..').click();
+  };
+
+  it('should detect MST and display log entries', async () => {
+    // The MST tab should appear since casablanca uses mobx-state-tree
+    const mstTab = devtoolPage.locator('[data-test="MainMenu-Tab-mst"]');
+    await mstTab.waitFor({ timeout: 15000 });
+    await mstTab.click();
+    await devtoolPage.waitForTimeout(500);
+
+    // MST recording auto-starts (mstLogEnabled defaults to true),
+    // so the initial snapshot should appear without clicking record
+    const initialItem = devtoolPage.locator('text=Initial');
+    await initialItem.waitFor({ timeout: 10000 });
+    assert.isTrue(await initialItem.isVisible(), 'Initial snapshot should appear');
+
+    // Add todos to trigger MST patches
+    await addTodo('Buy milk');
+    await addTodo('Walk the dog');
+    await devtoolPage.waitForTimeout(2000);
+
+    // Log items with patches should appear
+    const patchItems = devtoolPage.locator('text=/\\d+ patch/');
+    assert.isAtLeast(await patchItems.count(), 2, 'Expected at least 2 patch log entries');
+
+    // Player progress should reflect all log items (initial + patches)
+    const playerProgress = devtoolPage.locator('text=/\\d+ \\/ \\d+/');
+    const progressText = await playerProgress.innerText();
+    const total = Number(progressText.split('/')[1].trim());
+    assert.isAtLeast(total, 3, 'Player should show at least 3 items');
+  });
+
+  it('should show snapshot details when a log item is selected', async () => {
+    // Click a patch log item (not "Initial" which has no snapshot)
+    await devtoolPage.locator('text=/\\d+ patch/').first().click();
+    await devtoolPage.waitForTimeout(2000);
+
+    // The LogItemExplorer should show a "State" collapsible with the snapshot
+    const stateHeader = devtoolPage.locator('text=State');
+    await stateHeader.waitFor({ timeout: 5000 });
+    assert.isTrue(await stateHeader.isVisible(), '"State" section should be visible');
+
+    // Patch details should reference the todos path
+    const pageContent = await devtoolPage.content();
+    assert.isTrue(pageContent.includes('todos'), 'Patch details should reference todos path');
+  });
+
+  it('should clear log entries', async () => {
+    assert.isAtLeast(await devtoolPage.locator('text=/\\d+ patch/').count(), 1);
+
+    await clickClearButton();
+    await devtoolPage.waitForTimeout(1000);
+
+    // After commitAll, patch entries are removed — only the latest state remains as "Initial"
+    assert.equal(await devtoolPage.locator('text=/\\d+ patch/').count(), 0,
+      'Patch entries should be cleared');
+    assert.isAtLeast(await devtoolPage.locator('text=Initial').count(), 1,
+      'Initial snapshot should remain');
+  });
+});

--- a/test/e2e/mstDevtool.js
+++ b/test/e2e/mstDevtool.js
@@ -22,7 +22,7 @@ describe('MST tab', function test() {
     if (teardown) await teardown();
   });
 
-  const addTodo = async (title) => {
+  const addTodo = async title => {
     const input = mainPage.locator('input');
     await input.fill(title);
     await input.press('Enter');
@@ -84,9 +84,15 @@ describe('MST tab', function test() {
     await devtoolPage.waitForTimeout(1000);
 
     // After commitAll, patch entries are removed — only the latest state remains as "Initial"
-    assert.equal(await devtoolPage.locator('text=/\\d+ patch/').count(), 0,
-      'Patch entries should be cleared');
-    assert.isAtLeast(await devtoolPage.locator('text=Initial').count(), 1,
-      'Initial snapshot should remain');
+    assert.equal(
+      await devtoolPage.locator('text=/\\d+ patch/').count(),
+      0,
+      'Patch entries should be cleared',
+    );
+    assert.isAtLeast(
+      await devtoolPage.locator('text=Initial').count(),
+      1,
+      'Initial snapshot should remain',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Replace the dummy e2e test (`assert.ok(true)`) with real tests for the **Changes tab**: recording/displaying MobX actions, text and regex filtering, clearing log, and toggling recording off
- Add new e2e test file for the **MST tab**: detecting mobx-state-tree, displaying initial snapshot and patch log entries, viewing snapshot details in the explorer, and clearing log entries
