### PR TITLE
test: Add e2e test for Chrome DevTools panel & add data-hooks

### DIFF
--- a/src/frontend/SecondaryPanel/ButtonClear.jsx
+++ b/src/frontend/SecondaryPanel/ButtonClear.jsx
@@ -6,7 +6,7 @@ export default class ButtonClear extends React.PureComponent {
   render() {
     return (
       // eslint-disable-next-line react/jsx-props-no-spreading
-      <div className={css(styles.button)} {...this.props}>
+      <div className={css(styles.button)} data-hook="ButtonClear" {...this.props}>
         <ClearIcon />
       </div>
     );

--- a/src/frontend/SecondaryPanel/ButtonRecord.jsx
+++ b/src/frontend/SecondaryPanel/ButtonRecord.jsx
@@ -11,7 +11,7 @@ ButtonRecord.propTypes = {
 
 export default function ButtonRecord({ active, onClick, showTipStartRecoding }) {
   return (
-    <div className={css(styles.button)} onClick={onClick}>
+    <div className={css(styles.button)} data-hook="ButtonRecord" onClick={onClick}>
       <span className={css(styles.record, active && styles.recordActive)} />
       {showTipStartRecoding && (
         <div className={css(styles.tipStartRecoding)}>

--- a/test/e2e/devtoolsPanel.js
+++ b/test/e2e/devtoolsPanel.js
@@ -1,0 +1,195 @@
+const { assert } = require('chai');
+const { chromium } = require('playwright');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const http = require('http');
+const WebSocket = require('ws');
+const { startDevServer } = require('../../packages/playground/webpack.makeConfig');
+
+const extensionPath = path.join(__dirname, '../../lib/chrome');
+const debugPort = 9333;
+const cmdKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+function httpGetJson(url) {
+  return new Promise((resolve, reject) => {
+    http
+      .get(url, res => {
+        let data = '';
+        res.on('data', chunk => (data += chunk));
+        res.on('end', () => resolve(JSON.parse(data)));
+      })
+      .on('error', reject);
+  });
+}
+
+/**
+ * Persistent CDP connection to a target via raw WebSocket.
+ * Panel.html is an iframe target inside DevTools, so Playwright can't get a Page
+ * object for it. This thin wrapper lets us evaluate JS in the panel directly.
+ */
+class CDPConnection {
+  constructor(wsUrl) {
+    this._ws = null;
+    this._wsUrl = wsUrl;
+    this._nextId = 1;
+    this._pending = new Map();
+  }
+
+  connect() {
+    return new Promise((resolve, reject) => {
+      this._ws = new WebSocket(this._wsUrl);
+      this._ws.on('open', resolve);
+      this._ws.on('message', data => {
+        const msg = JSON.parse(data.toString());
+        const entry = this._pending.get(msg.id);
+        if (entry) {
+          this._pending.delete(msg.id);
+          msg.error ? entry.reject(new Error(msg.error.message)) : entry.resolve(msg.result);
+        }
+      });
+      this._ws.on('error', reject);
+    });
+  }
+
+  async evaluate(expression) {
+    const id = this._nextId++;
+    const result = await new Promise((resolve, reject) => {
+      this._pending.set(id, { resolve, reject });
+      this._ws.send(
+        JSON.stringify({
+          id,
+          method: 'Runtime.evaluate',
+          params: { expression, returnByValue: true, awaitPromise: true },
+        }),
+      );
+      setTimeout(() => {
+        if (this._pending.delete(id)) reject(new Error('CDP evaluate timeout'));
+      }, 15000);
+    });
+    return JSON.parse(result.result?.value || 'null');
+  }
+
+  close() {
+    if (this._ws) this._ws.close();
+  }
+}
+
+describe('DevTools panel', function test() {
+  let cdpBrowser;
+  let context;
+  let mainPage;
+  let panelCDP;
+  let closePlayground;
+  let userDataDir;
+  this.timeout(100000);
+
+  before(async () => {
+    closePlayground = await startDevServer({ port: 8082, pages: ['baltimore'] });
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mobx-devtools-panel-test-'));
+
+    context = await chromium.launchPersistentContext(userDataDir, {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+        `--auto-open-devtools-for-tabs`,
+        `--remote-debugging-port=${debugPort}`,
+        '--window-size=1800,1000',
+      ],
+    });
+
+    mainPage = context.pages()[0] || (await context.newPage());
+    await mainPage.goto('http://localhost:8082/baltimore.html');
+    await mainPage.waitForTimeout(8000);
+
+    // The panel-loader polls for MobX on the page then calls
+    // chrome.devtools.panels.create(). In automated runs the polling can miss,
+    // so we trigger panel creation explicitly from the panel-loader context.
+    const targets = await httpGetJson(`http://127.0.0.1:${debugPort}/json`);
+    const loaderTarget = targets.find(t => t.url.includes('panel-loader.html'));
+    assert.ok(loaderTarget, 'panel-loader.html target should exist');
+
+    const loaderCDP = new CDPConnection(loaderTarget.webSocketDebuggerUrl);
+    await loaderCDP.connect();
+    await loaderCDP.evaluate(`new Promise(resolve => {
+      chrome.devtools.panels.create('MobX', '', 'panel.html', () => resolve(JSON.stringify('ok')));
+    })`);
+    loaderCDP.close();
+    await mainPage.waitForTimeout(2000);
+
+    // panel.html only loads when the MobX tab is selected. Cycle through
+    // DevTools tabs with keyboard until the panel target appears.
+    const { webSocketDebuggerUrl } = await httpGetJson(
+      `http://127.0.0.1:${debugPort}/json/version`,
+    );
+    cdpBrowser = await chromium.connectOverCDP(webSocketDebuggerUrl);
+
+    let devtoolsPage;
+    for (const ctx of cdpBrowser.contexts()) {
+      for (const page of ctx.pages()) {
+        if (page.url().includes('devtools://devtools')) {
+          devtoolsPage = page;
+          break;
+        }
+      }
+    }
+    assert.ok(devtoolsPage, 'DevTools page should be reachable');
+    await devtoolsPage.bringToFront();
+
+    let panelTarget;
+    for (let i = 0; i < 15; i++) {
+      await devtoolsPage.keyboard.press(`${cmdKey}+]`);
+      await devtoolsPage.waitForTimeout(300);
+
+      const current = await httpGetJson(`http://127.0.0.1:${debugPort}/json`);
+      panelTarget = current.find(
+        t => t.url.includes('panel.html') && !t.url.includes('panel-loader'),
+      );
+      if (panelTarget) break;
+    }
+    assert.ok(panelTarget, 'panel.html target should appear after cycling tabs');
+
+    panelCDP = new CDPConnection(panelTarget.webSocketDebuggerUrl);
+    await panelCDP.connect();
+
+    // Wait for the React UI inside the panel to render
+    await mainPage.waitForTimeout(5000);
+  });
+
+  after(async () => {
+    if (closePlayground) closePlayground();
+    if (panelCDP) panelCDP.close();
+    if (cdpBrowser) await cdpBrowser.close().catch(() => {});
+    if (context) await context.close();
+    if (userDataDir) fs.rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  it('should load MobX panel and record changes', async () => {
+    // Verify the panel UI loaded
+    const tabs = await panelCDP.evaluate(`JSON.stringify(
+      Array.from(document.querySelectorAll('[data-test^="MainMenu-Tab"]'))
+        .map(t => t.textContent.trim())
+    )`);
+    assert.include(tabs, 'Changes', 'Changes tab should be visible');
+
+    // Start recording
+    await panelCDP.evaluate(`JSON.stringify((function() {
+      var toolbar = document.querySelector('input[placeholder="Search (string/regex)"]').parentElement;
+      toolbar.querySelector(':scope > div').click();
+      return 'ok';
+    })())`);
+    await mainPage.waitForTimeout(500);
+
+    // Trigger MobX actions on the main page
+    await mainPage.locator('button', { hasText: '+' }).click();
+    await mainPage.locator('button', { hasText: '+' }).click();
+    await mainPage.locator('button', { hasText: '–' }).click();
+    await mainPage.waitForTimeout(2000);
+
+    // Verify log entries appeared in the panel
+    const html = await panelCDP.evaluate(`JSON.stringify(document.body.innerHTML)`);
+    assert.include(html, 'manuallyIncrease', 'Expected manuallyIncrease log entries');
+    assert.include(html, 'manuallyDecrease', 'Expected manuallyDecrease log entries');
+  });
+});

--- a/test/e2e/devtoolsPanel.js
+++ b/test/e2e/devtoolsPanel.js
@@ -79,13 +79,17 @@ describe('DevTools panel', function test() {
 
     mainPage = context.pages()[0] || (await context.newPage());
     await mainPage.goto('http://localhost:8082/baltimore.html');
-    await mainPage.waitForTimeout(8000);
 
     // The panel-loader polls for MobX then calls chrome.devtools.panels.create().
     // In automated runs the polling can miss, so we trigger creation explicitly.
     // panel-loader.html is in a separate process, so we must use raw CDP here.
-    const targets = await httpGetJson(`http://127.0.0.1:${DEBUG_PORT}/json`);
-    const loaderTarget = targets.find(t => t.url.includes('panel-loader.html'));
+    // Poll until the panel-loader target appears (extension needs time to initialize).
+    let loaderTarget;
+    for (let i = 0; i < 30 && !loaderTarget; i++) {
+      const targets = await httpGetJson(`http://127.0.0.1:${DEBUG_PORT}/json`);
+      loaderTarget = targets.find(t => t.url.includes('panel-loader.html'));
+      if (!loaderTarget) await mainPage.waitForTimeout(500);
+    }
     assert.ok(loaderTarget, 'panel-loader.html target should exist');
 
     await cdpEvaluate(
@@ -94,7 +98,6 @@ describe('DevTools panel', function test() {
         chrome.devtools.panels.create('MobX', '', 'panel.html', () => resolve());
       })`,
     );
-    await mainPage.waitForTimeout(2000);
 
     // Connect to the DevTools page via CDP (Playwright doesn't expose devtools:// pages directly)
     const { webSocketDebuggerUrl } = await httpGetJson(
@@ -137,18 +140,18 @@ describe('DevTools panel', function test() {
     const tabs = panelFrame.locator('[data-test^="MainMenu-Tab"]');
     assert.isAtLeast(await tabs.count(), 1, 'Should have at least one tab');
 
-    // Start recording
+    // Start recording and wait for the tip to disappear (confirms recording is active)
     await panelFrame.locator('[data-hook="ButtonRecord"]').click();
-    await mainPage.waitForTimeout(500);
+    await panelFrame.locator('text=Click to start recording').waitFor({ state: 'hidden' });
 
     // Trigger MobX actions on the main page
     await mainPage.locator('button', { hasText: '+' }).click();
     await mainPage.locator('button', { hasText: '+' }).click();
     await mainPage.locator('button', { hasText: '–' }).click();
-    await mainPage.waitForTimeout(2000);
 
     // Verify log entries appeared in the panel
-    await panelFrame.locator('text=manuallyIncrease').first().waitFor({ timeout: 5000 });
+    await panelFrame.locator('text=manuallyIncrease').first().waitFor();
+    await panelFrame.locator('text=manuallyDecrease').first().waitFor();
     assert.isAtLeast(
       await panelFrame.locator('text=manuallyIncrease').count(),
       1,

--- a/test/e2e/devtoolsPanel.js
+++ b/test/e2e/devtoolsPanel.js
@@ -8,8 +8,8 @@ const WebSocket = require('ws');
 const { startDevServer } = require('../../packages/playground/webpack.makeConfig');
 
 const extensionPath = path.join(__dirname, '../../lib/chrome');
-const debugPort = 9333;
-const cmdKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+const DEBUG_PORT = 9333;
+const CMD_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
 
 function httpGetJson(url) {
   return new Promise((resolve, reject) => {
@@ -23,69 +23,48 @@ function httpGetJson(url) {
   });
 }
 
-/**
- * Persistent CDP connection to a target via raw WebSocket.
- * Panel.html is an iframe target inside DevTools, so Playwright can't get a Page
- * object for it. This thin wrapper lets us evaluate JS in the panel directly.
- */
-class CDPConnection {
-  constructor(wsUrl) {
-    this._ws = null;
-    this._wsUrl = wsUrl;
-    this._nextId = 1;
-    this._pending = new Map();
-  }
-
-  connect() {
-    return new Promise((resolve, reject) => {
-      this._ws = new WebSocket(this._wsUrl);
-      this._ws.on('open', resolve);
-      this._ws.on('message', data => {
-        const msg = JSON.parse(data.toString());
-        const entry = this._pending.get(msg.id);
-        if (entry) {
-          this._pending.delete(msg.id);
-          msg.error ? entry.reject(new Error(msg.error.message)) : entry.resolve(msg.result);
-        }
-      });
-      this._ws.on('error', reject);
-    });
-  }
-
-  async evaluate(expression) {
-    const id = this._nextId++;
-    const result = await new Promise((resolve, reject) => {
-      this._pending.set(id, { resolve, reject });
-      this._ws.send(
+// Extension iframes inside DevTools (e.g. panel-loader.html) live in a separate
+// process that Playwright can't reach via page.frames(). This helper sends a
+// single CDP evaluate call over a raw WebSocket to such a target.
+function cdpEvaluate(wsUrl, expression) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+    ws.on('open', () => {
+      ws.send(
         JSON.stringify({
-          id,
+          id: 1,
           method: 'Runtime.evaluate',
           params: { expression, returnByValue: true, awaitPromise: true },
         }),
       );
-      setTimeout(() => {
-        if (this._pending.delete(id)) reject(new Error('CDP evaluate timeout'));
-      }, 15000);
     });
-    return JSON.parse(result.result?.value || 'null');
-  }
-
-  close() {
-    if (this._ws) this._ws.close();
-  }
+    ws.on('message', data => {
+      const msg = JSON.parse(data.toString());
+      if (msg.id === 1) {
+        ws.close();
+        if (msg.error) reject(new Error(msg.error.message));
+        else resolve(msg.result);
+      }
+    });
+    ws.on('error', reject);
+    setTimeout(() => {
+      ws.close();
+      reject(new Error('CDP evaluate timeout'));
+    }, 15000);
+  });
 }
 
 describe('DevTools panel', function test() {
   let cdpBrowser;
   let context;
   let mainPage;
-  let panelCDP;
+  let panelFrame;
   let closePlayground;
   let userDataDir;
   this.timeout(100000);
 
   before(async () => {
-    closePlayground = await startDevServer({ port: 8082, pages: ['baltimore'] });
+    closePlayground = await startDevServer({ pages: ['baltimore'] });
     userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mobx-devtools-panel-test-'));
 
     context = await chromium.launchPersistentContext(userDataDir, {
@@ -94,8 +73,7 @@ describe('DevTools panel', function test() {
         `--disable-extensions-except=${extensionPath}`,
         `--load-extension=${extensionPath}`,
         `--auto-open-devtools-for-tabs`,
-        `--remote-debugging-port=${debugPort}`,
-        '--window-size=1800,1000',
+        `--remote-debugging-port=${DEBUG_PORT}`,
       ],
     });
 
@@ -103,63 +81,52 @@ describe('DevTools panel', function test() {
     await mainPage.goto('http://localhost:8082/baltimore.html');
     await mainPage.waitForTimeout(8000);
 
-    // The panel-loader polls for MobX on the page then calls
-    // chrome.devtools.panels.create(). In automated runs the polling can miss,
-    // so we trigger panel creation explicitly from the panel-loader context.
-    const targets = await httpGetJson(`http://127.0.0.1:${debugPort}/json`);
+    // The panel-loader polls for MobX then calls chrome.devtools.panels.create().
+    // In automated runs the polling can miss, so we trigger creation explicitly.
+    // panel-loader.html is in a separate process, so we must use raw CDP here.
+    const targets = await httpGetJson(`http://127.0.0.1:${DEBUG_PORT}/json`);
     const loaderTarget = targets.find(t => t.url.includes('panel-loader.html'));
     assert.ok(loaderTarget, 'panel-loader.html target should exist');
 
-    const loaderCDP = new CDPConnection(loaderTarget.webSocketDebuggerUrl);
-    await loaderCDP.connect();
-    await loaderCDP.evaluate(`new Promise(resolve => {
-      chrome.devtools.panels.create('MobX', '', 'panel.html', () => resolve(JSON.stringify('ok')));
-    })`);
-    loaderCDP.close();
+    await cdpEvaluate(
+      loaderTarget.webSocketDebuggerUrl,
+      `new Promise(resolve => {
+        chrome.devtools.panels.create('MobX', '', 'panel.html', () => resolve());
+      })`,
+    );
     await mainPage.waitForTimeout(2000);
 
-    // panel.html only loads when the MobX tab is selected. Cycle through
-    // DevTools tabs with keyboard until the panel target appears.
+    // Connect to the DevTools page via CDP (Playwright doesn't expose devtools:// pages directly)
     const { webSocketDebuggerUrl } = await httpGetJson(
-      `http://127.0.0.1:${debugPort}/json/version`,
+      `http://127.0.0.1:${DEBUG_PORT}/json/version`,
     );
     cdpBrowser = await chromium.connectOverCDP(webSocketDebuggerUrl);
 
-    let devtoolsPage;
-    for (const ctx of cdpBrowser.contexts()) {
-      for (const page of ctx.pages()) {
-        if (page.url().includes('devtools://devtools')) {
-          devtoolsPage = page;
-          break;
-        }
-      }
-    }
+    const devtoolsPage = cdpBrowser
+      .contexts()
+      .flatMap(ctx => ctx.pages())
+      .find(page => page.url().includes('devtools://devtools'));
     assert.ok(devtoolsPage, 'DevTools page should be reachable');
+
+    // panel.html only loads when the MobX tab is selected. Cycle through
+    // DevTools tabs with keyboard until the panel frame appears.
     await devtoolsPage.bringToFront();
 
-    let panelTarget;
-    for (let i = 0; i < 15; i++) {
-      await devtoolsPage.keyboard.press(`${cmdKey}+]`);
+    for (let i = 0; i < 15 && !panelFrame; i++) {
+      await devtoolsPage.keyboard.press(`${CMD_KEY}+]`);
       await devtoolsPage.waitForTimeout(300);
-
-      const current = await httpGetJson(`http://127.0.0.1:${debugPort}/json`);
-      panelTarget = current.find(
-        t => t.url.includes('panel.html') && !t.url.includes('panel-loader'),
-      );
-      if (panelTarget) break;
+      panelFrame = devtoolsPage
+        .frames()
+        .find(f => f.url().includes('panel.html') && !f.url().includes('panel-loader'));
     }
-    assert.ok(panelTarget, 'panel.html target should appear after cycling tabs');
-
-    panelCDP = new CDPConnection(panelTarget.webSocketDebuggerUrl);
-    await panelCDP.connect();
+    assert.ok(panelFrame, 'panel.html frame should appear after cycling tabs');
 
     // Wait for the React UI inside the panel to render
-    await mainPage.waitForTimeout(5000);
+    await panelFrame.locator('[data-test="MainMenu-Tab-changes"]').waitFor({ timeout: 15000 });
   });
 
   after(async () => {
     if (closePlayground) closePlayground();
-    if (panelCDP) panelCDP.close();
     if (cdpBrowser) await cdpBrowser.close().catch(() => {});
     if (context) await context.close();
     if (userDataDir) fs.rmSync(userDataDir, { recursive: true, force: true });
@@ -167,18 +134,11 @@ describe('DevTools panel', function test() {
 
   it('should load MobX panel and record changes', async () => {
     // Verify the panel UI loaded
-    const tabs = await panelCDP.evaluate(`JSON.stringify(
-      Array.from(document.querySelectorAll('[data-test^="MainMenu-Tab"]'))
-        .map(t => t.textContent.trim())
-    )`);
-    assert.include(tabs, 'Changes', 'Changes tab should be visible');
+    const tabs = panelFrame.locator('[data-test^="MainMenu-Tab"]');
+    assert.isAtLeast(await tabs.count(), 1, 'Should have at least one tab');
 
     // Start recording
-    await panelCDP.evaluate(`JSON.stringify((function() {
-      var toolbar = document.querySelector('input[placeholder="Search (string/regex)"]').parentElement;
-      toolbar.querySelector(':scope > div').click();
-      return 'ok';
-    })())`);
+    await panelFrame.locator('[data-hook="ButtonRecord"]').click();
     await mainPage.waitForTimeout(500);
 
     // Trigger MobX actions on the main page
@@ -188,8 +148,16 @@ describe('DevTools panel', function test() {
     await mainPage.waitForTimeout(2000);
 
     // Verify log entries appeared in the panel
-    const html = await panelCDP.evaluate(`JSON.stringify(document.body.innerHTML)`);
-    assert.include(html, 'manuallyIncrease', 'Expected manuallyIncrease log entries');
-    assert.include(html, 'manuallyDecrease', 'Expected manuallyDecrease log entries');
+    await panelFrame.locator('text=manuallyIncrease').first().waitFor({ timeout: 5000 });
+    assert.isAtLeast(
+      await panelFrame.locator('text=manuallyIncrease').count(),
+      1,
+      'Expected manuallyIncrease log entries',
+    );
+    assert.isAtLeast(
+      await panelFrame.locator('text=manuallyDecrease').count(),
+      1,
+      'Expected manuallyDecrease log entries',
+    );
   });
 });

--- a/test/e2e/mobxReactObservers.js
+++ b/test/e2e/mobxReactObservers.js
@@ -23,13 +23,11 @@ describe('Changes tab', function test() {
   });
 
   const startRecording = async () => {
-    const toolbar = devtoolPage.locator('input[placeholder="Search (string/regex)"]').locator('..');
-    await toolbar.locator('> div').first().click();
+    await devtoolPage.locator('[data-hook="ButtonRecord"]').click();
   };
 
   const clickClearButton = async () => {
-    const toolbar = devtoolPage.locator('input[placeholder="Search (string/regex)"]').locator('..');
-    await toolbar.locator('> div').nth(1).click();
+    await devtoolPage.locator('[data-hook="ButtonClear"]').click();
   };
 
   it('should record and display MobX changes', async () => {

--- a/test/e2e/mstDevtool.js
+++ b/test/e2e/mstDevtool.js
@@ -29,8 +29,7 @@ describe('MST tab', function test() {
   };
 
   const clickClearButton = async () => {
-    // Click the parent div of the ClearIcon SVG (which has a unique circle with r="5.75")
-    await devtoolPage.locator('svg:has(circle[r="5.75"])').locator('..').click();
+    await devtoolPage.locator('[data-hook="ButtonClear"]').click();
   };
 
   it('should detect MST and display log entries', async () => {


### PR DESCRIPTION
## Summary
- Adds an e2e test that verifies the MobX extension loads and works inside the Chrome DevTools panel (as opposed to the existing tests that only cover the separate popup window)
- Uses raw CDP WebSocket connection to interact with `panel.html` since it loads as an iframe target inside DevTools, which Playwright can't expose as a `Page` object
- Forces panel creation via the `panel-loader.html` context and navigates to the MobX tab using keyboard shortcuts (`Meta+]` / `Ctrl+]`)

## Status
Work-in-progress — the test passes in isolation but needs stabilization:
- `--auto-open-devtools-for-tabs` causes a race with `about:blank` on launch
- Need to open DevTools via CDP after navigation instead
- Running alongside existing tests needs port isolation
