### PR TITLE
fix: Prevent crash when Popover repositions after unmount

### DIFF
--- a/src/frontend/Popover.jsx
+++ b/src/frontend/Popover.jsx
@@ -169,6 +169,7 @@ class PopoverBubble extends Component {
   }
 
   reposition = () => {
+    if (!this.el || !this.props.triggerHtmlElement) return;
     const { triggerHtmlElement, placement } = this.props;
     const selfRect = rectFromEl(this.el);
     const triggerRect = rectFromEl(triggerHtmlElement);
@@ -198,6 +199,7 @@ class PopoverBubble extends Component {
           />
         )}
         <div
+          data-hook="Popover"
           className={css(styles.popover, popoverStyleForPlacement(placement))}
           style={{
             top: bodyCoordinates.top,

--- a/src/frontend/TabChanges/ChangeDataViewerPopover.jsx
+++ b/src/frontend/TabChanges/ChangeDataViewerPopover.jsx
@@ -60,6 +60,7 @@ export default function ChangeDataViewerPopover({
       onShown={() => inspect(path)} // eslint-disable-line react/jsx-no-bind
     >
       <span
+        data-hook="ChangeDataViewerPopover"
         className={`${css(styles.trigger)} ${className}`}
         // eslint-disable-next-line react/jsx-no-bind
         onContextMenu={e => {

--- a/test/e2e/mobxReactObservers.js
+++ b/test/e2e/mobxReactObservers.js
@@ -62,6 +62,31 @@ describe('Changes tab', function test() {
     );
   });
 
+  it('should open object popover', async () => {
+    // Expand a log item by clicking on it
+    await devtoolPage.locator('text=manuallyIncrease').first().click();
+
+    // Click the {…} object trigger to open the popover
+    const trigger = devtoolPage.locator('[data-hook="ChangeDataViewerPopover"]').first();
+    await trigger.waitFor();
+    await trigger.click();
+
+    // The popover should show a DataViewer with object properties
+    const popover = devtoolPage.locator('[data-hook="Popover"]');
+    await popover.waitFor();
+    assert.isTrue(await popover.isVisible(), 'Popover should be visible');
+    assert.isAtLeast(
+      (await popover.textContent()).length,
+      1,
+      'Popover should have content',
+    );
+
+    // Close the popover by clicking outside
+    await devtoolPage.locator('[data-hook="ButtonRecord"]').click();
+    // Re-enable recording for subsequent tests
+    await devtoolPage.locator('[data-hook="ButtonRecord"]').click();
+  });
+
   it('should filter log entries by text and regex search', async () => {
     const searchInput = devtoolPage.locator('input[placeholder="Search (string/regex)"]');
 

--- a/test/e2e/mobxReactObservers.js
+++ b/test/e2e/mobxReactObservers.js
@@ -75,11 +75,7 @@ describe('Changes tab', function test() {
     const popover = devtoolPage.locator('[data-hook="Popover"]');
     await popover.waitFor();
     assert.isTrue(await popover.isVisible(), 'Popover should be visible');
-    assert.isAtLeast(
-      (await popover.textContent()).length,
-      1,
-      'Popover should have content',
-    );
+    assert.isAtLeast((await popover.textContent()).length, 1, 'Popover should have content');
 
     // Close the popover by clicking outside
     await devtoolPage.locator('[data-hook="ButtonRecord"]').click();


### PR DESCRIPTION
Clicking an object ({…}) inside a Changes tab log item would trigger
repeated "Cannot read properties of null (reading 'getBoundingClientRect')"
errors. The Popover's reposition method runs on a 100ms interval and on
scroll/resize events, but didn't guard against this.el or triggerHtmlElement
being null after the component unmounts.

Add a null guard at the top of reposition, add an e2e test that opens the
object popover and verifies it renders with content.