### PR TITLE
chore: Add engines field to enforce Node.js >=20 requirement

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://registry.npmjs.org/
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "bootstrap": "npm install && lerna bootstrap",
     "build": "cross-env lerna run build && cross-env npm run build:chrome && npm run build:firefox",

--- a/packages/mobx-devtools-mst/package.json
+++ b/packages/mobx-devtools-mst/package.json
@@ -1,6 +1,9 @@
 {
     "name": "mobx-devtools-mst",
     "version": "0.9.32",
+    "engines": {
+        "node": ">=20"
+    },
     "main": "lib/index.js",
     "typings": "index.d.ts",
     "repository": {

--- a/packages/mobx-devtools/package.json
+++ b/packages/mobx-devtools/package.json
@@ -1,6 +1,9 @@
 {
     "name": "mobx-devtools",
     "version": "0.9.32",
+    "engines": {
+        "node": ">=20"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/mobxjs/mobx-devtools.git"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -2,6 +2,9 @@
     "private": true,
     "name": "mobx-devtools-playground",
     "version": "0.9.32",
+    "engines": {
+        "node": ">=20"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/mobxjs/mobx-devtools.git"


### PR DESCRIPTION
## Summary
- Add `"engines": { "node": ">=20" }` to all four package.json files (root, mobx-devtools, mobx-devtools-mst, playground)
- Add `engine-strict=true` to `.npmrc` so npm enforces the constraint during install
- Aligns package.json with the existing `.nvmrc` (20.17.0) and CI workflow configuration, which both already require Node 20
