### PR TITLE
chore: Clean up unused variables

### DIFF
--- a/src/backend/mobxLog.js
+++ b/src/backend/mobxLog.js
@@ -93,7 +93,7 @@ export default bridge => {
   ];
 
   return {
-    setup(mobxid, collection) {
+    setup(_mobxid, collection) {
       if (collection.mobx) {
         disposables.push(
           collection.mobx.spy(change => {

--- a/src/frontend/TabChanges/ChangeDataViewerPopover.jsx
+++ b/src/frontend/TabChanges/ChangeDataViewerPopover.jsx
@@ -45,7 +45,7 @@ export default function ChangeDataViewerPopover({
       stopInspecting={stopInspecting}
       showMenu={showMenu}
       decorator={injectStores({
-        subscribe: (stores, props) => ({
+        subscribe: (_stores, props) => ({
           actionsLoggerStore: [`inspected--${props.path.join('/')}`],
         }),
         shouldUpdate: () => true,

--- a/src/shells/webextension/background.js
+++ b/src/shells/webextension/background.js
@@ -1,5 +1,3 @@
-import debugConnection from '../../utils/debugConnection';
-
 /*
  * background.js
  *
@@ -48,10 +46,6 @@ function openWindow(tabId) {
       chrome.tabs.onRemoved.addListener(closeListener);
     },
   );
-}
-
-function isNumeric(str) {
-  return `${+str}` === str;
 }
 
 function handleInstallError(tabId, error) {
@@ -138,7 +132,7 @@ chrome.runtime.onConnect.addListener(port => {
 });
 
 // Respond with contentTabId for the devtools window
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (message.type === 'get-content-tab-id') {
     sendResponse({ contentTabId });
     return;
@@ -146,7 +140,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 // Handle messages from panel
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message, _sender, _sendResponse) => {
   if (message.type === 'panel-to-backend') {
     // Use the existing port to send to content script
     const port = contentScriptPorts.get(message.tabId);

--- a/src/shells/webextension/window.jsx
+++ b/src/shells/webextension/window.jsx
@@ -37,7 +37,7 @@ const inject = (contentTabId, done) =>
             .then(() => {
               const wall = {
                 listen(fn) {
-                  chrome.runtime.onMessage.addListener((message, sender) => {
+                  chrome.runtime.onMessage.addListener((message, _sender) => {
                     if (message.tabId === contentTabId) {
                       debugConnection('[background -> FRONTEND]', message);
                       fn(message.data);


### PR DESCRIPTION
## Summary
- Remove unused `debugConnection` import and unused `isNumeric` function from `background.js`
- Prefix unused positional parameters (`sender`, `sendResponse`, `mobxid`, `stores`) with `_` in `background.js`, `window.jsx`, `mobxLog.js`, and `ChangeDataViewerPopover.jsx`
